### PR TITLE
Don't override Meteor.user() to deal with guest logins, as many

### DIFF
--- a/accounts-guest-client.js
+++ b/accounts-guest-client.js
@@ -32,10 +32,10 @@ if (Package.blaze) {
 
 	//no non-logged in users
 	/* you might need to limit this to avoid flooding the user db */
-	Meteor.loginVisitor = function () {
+	Meteor.loginVisitor = function (email) {
 		AccountsGuest.forced = true;
 		if (!Meteor.userId()) {
-			Meteor.call('createGuest',function (error, result) {
+			Meteor.call('createGuest', email, function (error, result) {
 				if (error) {
 					console.log('Error in creating Guest ' + error);
 					return false;
@@ -55,13 +55,13 @@ if (Package.blaze) {
 		}
 	}
 
-		Deps.autorun(function () {
+Deps.autorun(function () {
 
-			if (Meteor.userId()) {
-				//			console.log('this is '+Meteor.userId());
-			} else {
-				if (AccountsGuest.forced === true){
-					Meteor.loginVisitor();
-				}
-			}
-		});
+	if (Meteor.userId()) {
+		//			console.log('this is '+Meteor.userId());
+	} else {
+		if (AccountsGuest.forced === true){
+			Meteor.loginVisitor();
+		}
+	}
+});

--- a/accounts-guest-client.js
+++ b/accounts-guest-client.js
@@ -55,13 +55,15 @@ if (Package.blaze) {
 		}
 	}
 
-Deps.autorun(function () {
+Meteor.startup(function(){
+		Deps.autorun(function () {
 
-	if (Meteor.userId()) {
-		//			console.log('this is '+Meteor.userId());
-	} else {
-		if (AccountsGuest.forced === true){
-			Meteor.loginVisitor();
-		}
-	}
+			if (Meteor.userId()) {
+				//			console.log('this is '+Meteor.userId());
+			} else {
+				if (AccountsGuest.forced === true){
+					Meteor.loginVisitor();
+				}
+			}
+		});
 });

--- a/accounts-guest-client.js
+++ b/accounts-guest-client.js
@@ -4,22 +4,30 @@
 *
 */
 
-/* make anonymous users kinda non-users -- just ids
-* this allows the account-base "Sign-in" to still appear
-*/
-Meteor.user = function () {
-	var userId = Meteor.userId();
-	if (!userId) {
-		return null;
-	}
-	var user = Meteor.users.findOne(userId);
-	if (user !== undefined &&
-		user.profile !== undefined &&
-		user.profile.guest) {
-			return null;
-		}
-		return user;
-	};
+
+// If our app has a Blaze, override the {{currentUser}} helper to deal guest logins
+if (Package.blaze) {
+  /**
+   * @global
+   * @name  currentUser
+   * @isHelper true
+   * @summary Calls [Meteor.user()](#meteor_user). Use `{{#if currentUser}}` to check whether the user is logged in.
+   * Where "logged in" means: The user has has authenticated (e.g. through providing credentials)
+   */
+  Package.blaze.Blaze.Template.registerHelper('currentUser', function () {
+    var user = Meteor.user();
+    if (user &&
+        typeof user.profile !== 'undefined' &&
+        typeof user.profile.guest !== 'undefined' &&
+        user.profile.guest){
+        // a guest login is not a real login where the user is authenticated. 
+        // This allows the account-base "Sign-in" to still appear
+      return null;
+    }else{
+      return Meteor.user();
+    }
+  });
+}
 
 
 	//no non-logged in users

--- a/accounts-guest-server.js
+++ b/accounts-guest-server.js
@@ -1,7 +1,7 @@
 Accounts.removeOldGuests = function (before) {
   if (typeof before === 'undefined') {
-	before = new Date();
-	before.setHours(before.getHours() - 1);
+    before = new Date();
+    before.setHours(before.getHours() - 1);
   }
   res = Meteor.users.remove({createdAt: {$lte: before}, 'profile.guest': 'guest'});
   return res;
@@ -11,22 +11,28 @@ Accounts.removeOldGuests = function (before) {
 * See https://github.com/artwells/meteor-accounts-guest/commit/28cbbf0eca2d80f78925ac619abf53d0769c0d9d
 */
 Meteor.methods({
-	createGuest: function ()
-	{
-		/* if explicitly disabled, happily do nothing */
-		if (AccountsGuest.enabled === false){
-			return true;
-		}
-		count = Meteor.users.find().count() + 1
-		guestname = "guest-#" + count
-		guest = {
-			username: guestname,
-			email: guestname + "@example.com",
-			profile: {guest: true},
-			password: Meteor.uuid(),
-		};
-		Accounts.createUser(guest);
-//		console.log("createGuest" + guestname);
-		return guest;
-	}
+  createGuest: function (email)
+  {
+    /* if explicitly disabled, happily do nothing */
+    if (AccountsGuest.enabled === false){
+      return true;
+    }
+
+    count = Meteor.users.find().count() + 1
+    guestname = "guest-#" + count
+
+    if (!email) {
+      email = guestname + "@example.com";
+    } 
+
+    guest = {
+      username: guestname,
+      email: email,
+      profile: {guest: true},
+      password: Meteor.uuid(),
+    };
+    Accounts.createUser(guest);
+//    console.log("createGuest" + guestname);
+    return guest;
+  }
 });

--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.onUse(function (api) {
 	api.versionsFrom("METEOR@0.9.0");
-	api.use(['accounts-base', 'accounts-password','deps'], 'client');
+	api.use(['accounts-base', 'accounts-password','deps', 'blaze@2.0.4'], 'client');
 	api.use(['accounts-base'], 'server');
 	api.add_files('accounts-guest.js', ['client','server']);
 	api.export('AccountsGuest');


### PR DESCRIPTION
packages want to do something with the user object,
even if the logged in user is a guest user.

The original intention for the override was to allow the
accounts-base "Sign-In" to appear. This commit still allows exactly
that, but does not return an empty user record when calling
Meteor.user() as guest. (Which was not the expected behaviour anyway,
I would argue. Because the method name implies that you get a user
record, regardless if the user is guest or not.)