### PR TITLE
Random display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ In code available to client, to temporarily or conditionally disable guest login
 AccountsGuest.enabled = true
 ```
 
-
+In code available to server, to assign the guest a friendly nickname
+```javascript
+AccountsGuest.name = true
+```
 
 
 ##TODO

--- a/accounts-guest-client.js
+++ b/accounts-guest-client.js
@@ -18,7 +18,8 @@ if (Package.blaze) {
         if (user &&
             typeof user.profile !== 'undefined' &&
             typeof user.profile.guest !== 'undefined' &&
-            user.profile.guest){
+            user.profile.guest &&
+            AccountsGuest.name === false){
             // a guest login is not a real login where the user is authenticated.
             // This allows the account-base "Sign-in" to still appear
             return null;

--- a/accounts-guest-server.js
+++ b/accounts-guest-server.js
@@ -32,7 +32,6 @@ Meteor.methods({
         } else {
           guestname = "guest-#" + Random.id()
         }
-        console.log("Using username: " + guestname);
 
         if (!email) {
             email = guestname + "@example.com";

--- a/accounts-guest-server.js
+++ b/accounts-guest-server.js
@@ -1,3 +1,5 @@
+Moniker = Npm.require('moniker');
+
 Accounts.removeOldGuests = function (before) {
     if (typeof before === 'undefined') {
         before = new Date();
@@ -21,7 +23,16 @@ Meteor.methods({
         }
 
         //    count = Meteor.users.find().count() + 1
-        guestname = "guest-#" + Random.id()
+        if (AccountsGuest.name === true) {
+          guestname = Moniker.choose();
+          // Just in case, let's make sure this name isn't taken
+          while (Meteor.users.find({username:guestname}).count() > 0) {
+            guestname = Moniker.choose();
+          }
+        } else {
+          guestname = "guest-#" + Random.id()
+        }
+        console.log("Using username: " + guestname);
 
         if (!email) {
             email = guestname + "@example.com";

--- a/accounts-guest.js
+++ b/accounts-guest.js
@@ -5,3 +5,6 @@ if (typeof AccountsGuest.forced === "undefined") {
 if (typeof AccountsGuest.enabled === "undefined") {
 	AccountsGuest.enabled = true; /* on 'false'  Meteor.loginVisitor() will fail */
 }
+if (typeof AccountsGuest.name === "undefined") {
+  AccountsGuest.name = false; /* defaults to returning "null" for user's name */
+}

--- a/package.js
+++ b/package.js
@@ -25,3 +25,7 @@ Package.onTest(function (api) {
     api.add_files('accounts-guest-server-tests.js', 'server');
     api.add_files('accounts-guest-client-tests.js', 'client');
 });
+
+Npm.depends({
+    'moniker': '0.1.2'
+});


### PR DESCRIPTION
Utilizing Moniker, guest users are given random display names. This is
configurable by setting the variable `AccountsGuest.name` in server-side
code.