### PR TITLE
Fix currentUser when autopublish not installed.

### DIFF
--- a/accounts-guest-client-tests.js
+++ b/accounts-guest-client-tests.js
@@ -47,3 +47,62 @@ Tinytest.add(
 		test.isTrue((typeof uid !== undefined && typeof uid !== null), 'working');
 	}
 );
+
+Tinytest.add('guest - currentUser', function (test) {
+  // Define a template that looks up currentUser and tests it
+  var template = new Blaze.Template("test", function() {
+    var view = this;
+    var actualCurrentUser = view.lookup("currentUser")();
+    test.equal(actualCurrentUser, expectedCurrentUser);
+    return Spacebars.mustache(actualCurrentUser); // We don't need the output
+  });
+
+  // Stub Meteor.user
+  var origMeteorUser = Meteor.user;
+  Meteor.user = function() {
+    return user;
+  }
+
+  // Create a user object for our stub to return.
+  var user = {
+    emails: [ {address: true} ], // not a string
+    username: true, // not a string
+    profile: {
+      name: true // not a string
+    },
+		services: { } // Empty when autopublish package is not installed
+  };
+  var expectedCurrentUser = user;
+
+	// Test a marginally anonymous user.
+  expectedCurrentUser = null;
+  Blaze.toHTML(template);
+
+  // Test non-anonymous users
+  expectedCurrentUser = user;
+
+  // Test a non-anonymous user with only a profile.name
+  delete user.emails;
+  delete user.username;
+  user.profile.name = 'Test User';
+  Blaze.toHTML(template);
+
+  // Test a non-anonymous user with only an email address
+  delete user.profile;
+  user.emails = [ { address: 'test@example.com' }];
+  Blaze.toHTML(template);
+
+  // Test a non-anonymous user with only a username
+  delete user.emails;
+  user.username = 'testuser';
+  Blaze.toHTML(template);
+
+	// Test an explicit guest user
+  delete user.username;
+  user.profile = { guest: true };
+	expectedCurrentUser = null;
+  Blaze.toHTML(template);
+
+  // Unstub Meteor.user
+  Meteor.user = origMeteorUser;
+});

--- a/accounts-guest-client.js
+++ b/accounts-guest-client.js
@@ -15,19 +15,26 @@ if (Package.blaze) {
      */
     Package.blaze.Blaze.Template.registerHelper('currentUser', function () {
         var user = Meteor.user();
-        if (user && _.isEmpty(user.services))
+        if (! user) {
           return null;
-        if (user &&
-            typeof user.profile !== 'undefined' &&
+        }
+        if (typeof user.profile !== 'undefined' &&
             typeof user.profile.guest !== 'undefined' &&
             user.profile.guest &&
             AccountsGuest.name === false){
             // a guest login is not a real login where the user is authenticated.
             // This allows the account-base "Sign-in" to still appear
             return null;
-        } else {
-            return Meteor.user();
         }
+        // If the user has a username, a profile.name, or at least one email address,
+        // then they aren't anonymous, so return them.
+        if (typeof(user.username) === 'string'
+            || user.profile && typeof(user.profile.name) === 'string'
+            || (user.emails && user.emails.length > 0
+                && typeof(user.emails[0].address) === 'string')) {
+          return user;
+        }
+        return null;
     });
 }
 

--- a/package.js
+++ b/package.js
@@ -21,6 +21,7 @@ Package.onUse(function (api) {
 Package.onTest(function (api) {
     api.versionsFrom("METEOR@0.9.0");
     api.use(['accounts-base', 'accounts-password', 'mongo', 'tinytest','deps'], ['client','server']);
+    api.use('blaze@2.0.4');
     api.add_files('accounts-guest.js', ['client','server']);
     api.add_files('accounts-guest-server.js', 'server');
     api.add_files('accounts-guest-client.js', 'client');


### PR DESCRIPTION
When autopublish isn't installed, the services property is empty on the client,
so we can't use it to determine whether a user is an aonymous guest. Instead,
recognize anonymous guests by the absence of username, profile.name, and
emails[0].address.