### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Accounts.removeOldGuests(before);
 * `AccountsGuest.anonymous`,  default false. If true, do not require acccounts-password and make guests
   anonymous (i.e. no auto-generated username and email).
 
-##Option Examples
+## Option Examples
 
 In code available to server, to temporarily or conditionally disable guest login
 ```javascript


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
